### PR TITLE
Feature #9 Add thread safe pulseIn

### DIFF
--- a/Interact_Inputs.cpp
+++ b/Interact_Inputs.cpp
@@ -46,7 +46,7 @@ int initCapTouch(const uint8_t& pin, const uint16_t& threshold)
     return 0;
 }
 
-void IRAM_ATTR onLimitSwitch()
+void IRAM_ATTR onLimitSwitchISR()
 {
     BaseType_t xHigherPriorityWoken = pdFALSE, xResult;
     xResult = xEventGroupSetBitsFromISR(interactInputsEG, LIMIT_SWITCH_BIT, &xHigherPriorityWoken);
@@ -67,7 +67,7 @@ int initLimitSwitch(const uint8_t& pin, const int& triggerMode)
     else
         return -1;
     
-    attachInterrupt(pin, onLimitSwitch, triggerMode);
+    attachInterrupt(pin, onLimitSwitchISR, triggerMode);
 
     return 0;
 }

--- a/Interact_Inputs.h
+++ b/Interact_Inputs.h
@@ -47,7 +47,7 @@ int initCapTouch(const uint8_t& pin, const uint16_t& threshold);
  * @param pin The pin to be attached to the limit switch
  * @param triggerMode How interrupt is triggered, either RISING or FALLING
  */
-void IRAM_ATTR onLimitSwitch();
+void IRAM_ATTR onLimitSwitchISR();
 int initLimitSwitch(const uint8_t& pin, const int& triggerMode);
 
 /**

--- a/Ultrasonic.cpp
+++ b/Ultrasonic.cpp
@@ -1,0 +1,101 @@
+#include "Ultrasonic.h"
+
+#include "esp_timer.h"
+
+#define RISING_BIT  (1 << 0)
+#define FALLING_BIT (1 << 1)
+
+typedef struct pulseIn_t
+{
+    int64_t startTime;
+    int64_t endTime;
+    uint8_t state;
+    EventGroupHandle_t pulseInEG;
+} PulseIn_t;
+
+void IRAM_ATTR onRising(void* _curPulseIn)
+{
+    BaseType_t xHigherPriorityWoken = pdFALSE, xResult;
+    PulseIn_t* curPulseIn = (PulseIn_t*)_curPulseIn;
+
+    if (curPulseIn->state == HIGH)
+    {
+        curPulseIn->startTime = esp_timer_get_time();
+    }
+    else if (curPulseIn->state == LOW)
+    {
+        curPulseIn->endTime = esp_timer_get_time();
+        if (FALLING_BIT & xEventGroupGetBitsFromISR(curPulseIn->pulseInEG) == 0)     // hasn't detected falling edge
+        {
+            curPulseIn->endTime = -1;
+            return;
+        }
+    }
+
+    xResult = xEventGroupSetBitsFromISR(curPulseIn->pulseInEG, RISING_BIT, &xHigherPriorityWoken);
+    if (xResult != pdFAIL)
+        portYIELD_FROM_ISR(xHigherPriorityWoken);
+}
+
+void IRAM_ATTR onFalling(void* _curPulseIn)
+{
+    BaseType_t xHigherPriorityWoken = pdFALSE, xResult;
+    PulseIn_t* curPulseIn = (PulseIn_t*)_curPulseIn;
+
+    if (curPulseIn->state == LOW)
+    {
+        curPulseIn->startTime = esp_timer_get_time();
+    }
+    else if (curPulseIn->state == HIGH)
+    {
+        curPulseIn->endTime = esp_timer_get_time();
+        if (RISING_BIT & xEventGroupGetBitsFromISR(curPulseIn->pulseInEG) == 0)     // hasn't detected rising edge
+        {
+            curPulseIn->endTime = -1;
+            return;
+        }
+    }
+
+    xResult = xEventGroupSetBitsFromISR(curPulseIn->pulseInEG, FALLING_BIT, &xHigherPriorityWoken);
+    if (xResult != pdFAIL)
+        portYIELD_FROM_ISR(xHigherPriorityWoken);
+}
+
+int pulseInThreadSafe(const uint8_t& pin, const uint8_t& state, const uint32_t timeout)
+{
+    bool success = true;
+    PulseIn_t curPulseIn;
+    curPulseIn.startTime = -1;
+    curPulseIn.endTime   = -1;       // indicate the interrupt getting endtime cannot set event flag before the other
+    curPulseIn.state     = state;
+    curPulseIn.pulseInEG = xEventGroupCreate();
+
+    if (state == HIGH)
+    {
+        attachInterruptArg(pin,  onRising, (void*)&curPulseIn,  RISING);
+        attachInterruptArg(pin, onFalling, (void*)&curPulseIn, FALLING);
+    }
+    else if (state == LOW)
+    {
+        attachInterruptArg(pin, onFalling, (void*)&curPulseIn, FALLING);
+        attachInterruptArg(pin,  onRising, (void*)&curPulseIn,  RISING);
+    }
+
+    EventBits_t curBits;
+    curBits = xEventGroupWaitBits( curPulseIn.pulseInEG,
+                                   RISING_BIT | FALLING_BIT,
+                                   pdTRUE,
+                                   pdTRUE,
+                                   (timeout / 1000) / portTICK_PERIOD_MS );
+    if ( curBits & (RISING_BIT | FALLING_BIT) != (RISING_BIT | FALLING_BIT)   // timeout
+          || curPulseIn.startTime < 0 || curPulseIn.endTime < 0)
+        success = false;
+
+    detachInterrupt(pin);
+    vEventGroupDelete(curPulseIn.pulseInEG);
+
+    if (success)
+        return curPulseIn.endTime - curPulseIn.startTime;
+    else
+        return 0;
+}

--- a/Ultrasonic.h
+++ b/Ultrasonic.h
@@ -1,0 +1,19 @@
+#ifndef ULTRASONIC_H
+#define ULTRASONIC_H
+
+#include <Arduino.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+/**
+ * @brief Modify pulseIn to be thread safe by using interrupts
+ *        Should only be used in a Task!!
+ *
+ * @param pin The pin to be attached to pulse input
+ * @param state The state pulseIn should measure, HIGH or LOW
+ * @param timeout Timeout before the function returns 0
+ *
+ */
+int pulseInThreadSafe(const uint8_t& pin, const uint8_t& state, const uint32_t timeout = 1000000UL);
+
+#endif // ULTRASONIC_H


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

* **Is this PR related to an issue?**
Ultrasonic used `pulseIn()`, which is not thread safe

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Solved #9 

* **What is the new behavior (if this is a feature change)?**
`pulseIn()` is now thread safe
